### PR TITLE
Add performance comparison against Scala namer.

### DIFF
--- a/bench/jvm/src/main/scala/rsc/bench/ScalacNamer.scala
+++ b/bench/jvm/src/main/scala/rsc/bench/ScalacNamer.scala
@@ -1,0 +1,80 @@
+// Copyright (c) 2017 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0 (see LICENSE.md).
+package rsc.bench
+
+import java.nio.file._
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.annotations.Mode._
+import scala.tools.nsc._
+import scala.tools.nsc.reporters._
+import rsc.bench.ScalacNamer._
+import rsc.tests._
+
+object ScalacNamer {
+  @State(Scope.Benchmark)
+  class BenchmarkState extends RscFixtures
+}
+
+object CliScalacNamer {
+  def main(args: Array[String]): Unit = {
+    val Array(expectedScalacVersion) = args
+    val bs = new ScalacCompile.BenchmarkState
+    val outdir = Files.createTempDirectory("scalac_").toString
+    val fs = bs.re2sFiles.init.map(_.toString)
+    val stop = List("-Ystop-after:namer")
+    val command = List("scalac", "-d", outdir, "-usejavacp") ++ stop ++ fs
+    CliBench.run(command, runs = 100)
+  }
+}
+
+trait ScalacNamer {
+  def runImpl(bs: BenchmarkState): Unit = {
+    val settings = new Settings
+    settings.outdir.value = Files.createTempDirectory("scalac_").toString
+    settings.stopAfter.value = List("namer")
+    settings.usejavacp.value = true
+    val reporter = new StoreReporter
+    val global = Global(settings, reporter)
+    val run = new global.Run
+    run.compile(bs.re2sFiles.init.map(_.toString))
+    if (reporter.hasErrors) {
+      reporter.infos.foreach(println)
+      sys.error("typecheck failed")
+    }
+  }
+}
+
+@BenchmarkMode(Array(SingleShotTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(value = 128, jvmArgs = Array("-Xms2G", "-Xmx2G"))
+class ColdScalacNamer extends ScalacNamer {
+  @Benchmark
+  def run(bs: BenchmarkState): Unit = {
+    runImpl(bs)
+  }
+}
+
+@BenchmarkMode(Array(SampleTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgs = Array("-Xms2G", "-Xmx2G"))
+class WarmScalacNamer extends ScalacNamer {
+  @Benchmark
+  def run(bs: BenchmarkState): Unit = {
+    runImpl(bs)
+  }
+}
+
+@BenchmarkMode(Array(SampleTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3, jvmArgs = Array("-Xms2G", "-Xmx2G"))
+class HotScalacNamer extends ScalacNamer {
+  @Benchmark
+  def run(bs: BenchmarkState): Unit = {
+    runImpl(bs)
+  }
+}

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -90,12 +90,15 @@ To reproduce, run `sbt bench` (this will take a while).
 |--------------------|----------------------|----------------------|
 | RscNativeTypecheck | 300.146 ms           | 282.468 ms           |
 | RscTypecheck       | 476.843 ± 0.822 ms   | 33.685 ± 0.024 ms    |
+| ScalacNamer 2.12.4 | 1843.751 ± 14.930 ms | 29.825 ± 0.090 ms    |
+| ScalacNamer 2.11.11| 1423.331 ± 37.056 ms | 71.100 ± 0.318 ms    |
 | ScalacTypecheck    | 4326.812 ± 28.763 ms | 712.872 ± 3.554 ms   |
 | ScalacCompile      | 8098.704 ± 47.390 ms | 1691.732 ± 12.205 ms |
 | JavacCompile       | 851.787 ± 3.460 ms   | 76.164 ± 0.169 ms    |
 
 ## Comments
-
+  * Compared to the Scala namer in Scala 2.11.11, our prototype type-checker is about 2x faster.
+    However, compared to the namer in 2.12.4 we are about 10% slower.
   * First and foremost, we are happy to announce that typechecking in Rsc
     is currently way faster than in Scalac. Cold typechecking is ~9x faster and
     hot typechecking is a whopping ~21x faster at ~330kloc/s.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -68,9 +68,10 @@ object Build extends AutoPlugin {
       val benchRscNativeTypecheck = "benchCliRscNativeTypecheck"
       private val rscTyper = List("ColdRscTypecheck", "HotRscTypecheck")
       private val scalaTyper = List("ColdScalacTypecheck", "HotScalacTypecheck")
+      private val scalaNamer = List("ColdScalacNamer", "HotScalacNamer")
       private val scalaCompile = List("ColdScalacCompile", "HotScalacCompile")
       private val javaCompile = List("ColdJavacCompile", "HotScalacCompile")
-      private val all = rscTyper ++ scalaTyper ++ scalaCompile ++ javaCompile
+      private val all = rscTyper ++ scalaNamer ++ scalaTyper ++ scalaCompile ++ javaCompile
       val benchRscScalacJavac = "benchJVM/jmh:run " + all.mkString(" ")
       val benches = s"$benchRscNativeTypecheck ;$benchRscScalacJavac"
     }


### PR DESCRIPTION
Currently rsc does not have a type-checker that makes for a meaningful comparison against the Scala type-checker. Since Rsc currently do mostly name-resolution, a comparison against a similar phase in Scalac is useful.

|                    | Cold                 | Hot                  |
|--------------------|----------------------|----------------------|
| RscTypecheck       | 476.843 ± 0.822 ms   | 33.685 ± 0.024 ms    |
| ScalacNamer 2.12.4 | 1843.751 ± 14.930 ms | 29.825 ± 0.090 ms    |
| ScalacNamer 2.11.11| 1423.331 ± 37.056 ms | 71.100 ± 0.318 ms    |


The new numbers are interesting: compared to the namer in 2.12.4, rsc is 10% slower, but about 2x faster than the 2.11.11 namer in "hot" state. Things look a lot better for cold performance, where rsc is about 3x faster than the Scala namer.
