### PR TITLE
Avoid repeated calls to lexeme in hexadecimalNumber

### DIFF
--- a/rsc/src/main/scala/rsc/scan/Scanner.scala
+++ b/rsc/src/main/scala/rsc/scan/Scanner.scala
@@ -261,6 +261,7 @@ final class Scanner private (
       nextChar()
     }
     val parsee = {
+      val lexeme = this.lexeme
       if (lexeme.startsWith("-")) "-" + lexeme.substring(3)
       else lexeme.substring(2)
     }


### PR DESCRIPTION
lexeme was called 3 times on 2 lines, each generating a new String - replaced with single call.
(n.b. benchmark was against  @xeno-by 's perf branch benchJVM)
baseline

[info] Benchmark                            Mode   Cnt   Score   Error  Units
[info] QuickRscTypecheck.run              sample  2292  26.185 ± 0.190  ms/op
[info] QuickRscTypecheck.run:run·p0.00    sample        22.774          ms/op
[info] QuickRscTypecheck.run:run·p0.50    sample        25.706          ms/op
[info] QuickRscTypecheck.run:run·p0.90    sample        29.065          ms/op
[info] QuickRscTypecheck.run:run·p0.95    sample        30.147          ms/op
[info] QuickRscTypecheck.run:run·p0.99    sample        36.357          ms/op
[info] QuickRscTypecheck.run:run·p0.999   sample        53.437          ms/op
[info] QuickRscTypecheck.run:run·p0.9999  sample        60.490          ms/op
[info] QuickRscTypecheck.run:run·p1.00    sample        60.490          ms/op
lexeme2
[info] Benchmark                            Mode   Cnt   Score   Error  Units
[info] QuickRscTypecheck.run              sample  2378  25.248 ± 0.159  ms/op
[info] QuickRscTypecheck.run:run·p0.00    sample        21.725          ms/op
[info] QuickRscTypecheck.run:run·p0.50    sample        24.707          ms/op
[info] QuickRscTypecheck.run:run·p0.90    sample        28.184          ms/op
[info] QuickRscTypecheck.run:run·p0.95    sample        29.065          ms/op
[info] QuickRscTypecheck.run:run·p0.99    sample        31.893          ms/op
[info] QuickRscTypecheck.run:run·p0.999   sample        40.689          ms/op
[info] QuickRscTypecheck.run:run·p0.9999  sample        41.353          ms/op
[info] QuickRscTypecheck.run:run·p1.00    sample        41.353          ms/op