### PR TITLE
Store hashcode on Sids as they are used a lot

### DIFF
--- a/rsc/src/main/scala/rsc/semantics/Sids.scala
+++ b/rsc/src/main/scala/rsc/semantics/Sids.scala
@@ -10,6 +10,12 @@ sealed trait Sid extends Pretty with Product {
   def printRepl(p: Printer): Unit = PrettySid.repl(p, this)
 }
 
-final case class SomeSid(value: String) extends Sid
-final case class TermSid(value: String) extends Sid
-final case class TypeSid(value: String) extends Sid
+final case class SomeSid(value: String) extends Sid {
+  override val hashCode: Int = value.hashCode * 3
+}
+final case class TermSid(value: String) extends Sid {
+  override val hashCode: Int = value.hashCode * 5
+}
+final case class TypeSid(value: String) extends Sid {
+  override val hashCode: Int = value.hashCode * 7
+}


### PR DESCRIPTION
Sids are stored in Scopes in a hashmap - This prevents the default hashcode implementation going via Product hashcode to the underlying String.  Also by multiplying by different primes the different types of Sid should have better distribution.

Checked locally on my laptop with @xeno-by 's benchJVM test.

Before: 
[info] QuickRscTypecheck.run              sample  2422  24.790 ± 0.209  ms/op
After: 
[info] QuickRscTypecheck.run              sample  2504  23.975 ± 0.177  ms/op