### PR TITLE
Remove inessential position tracking

### DIFF
--- a/rsc/src/main/scala/rsc/report/Reporter.scala
+++ b/rsc/src/main/scala/rsc/report/Reporter.scala
@@ -2,10 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE.md).
 package rsc.report
 
-import rsc.lexis._
-
 trait Reporter {
-  var pos: Position = NoPosition
   def append(msg: Message): Message
   def problems: List[Message]
 }

--- a/rsc/src/main/scala/rsc/typecheck/Outliner.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Outliner.scala
@@ -13,12 +13,10 @@ final class Outliner private (
     reporter: Reporter,
     symtab: Symtab) {
   def apply(env: Env, tpt: Tpt): Unit = {
-    reporter.pos = tpt.point
     assignUids(env, tpt.atoms)
   }
 
   def apply(env: Env, mod: Mod): Unit = {
-    reporter.pos = mod.point
     mod match {
       case ModPrivate(Some(id: SomeId)) =>
         assignUids(env, id.atoms)

--- a/rsc/src/main/scala/rsc/typecheck/Scheduler.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Scheduler.scala
@@ -14,7 +14,6 @@ final class Scheduler private (
     symtab: Symtab,
     todo: Todo) {
   def apply(env: Env, tree: Tree): Env = {
-    reporter.pos = tree.point
     tree match {
       case tree: DefnDef => defnDef(env, tree)
       case tree: DefnField => defnField(env, tree)

--- a/rsc/src/main/scala/rsc/typecheck/Scoper.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Scoper.scala
@@ -19,14 +19,12 @@ final class Scoper private (
     }
     scope match {
       case scope: ImporterScope =>
-        reporter.pos = scope.tree.point
         trySucceed(env, scope)
       case scope: FlatScope =>
         unreachable(scope)
       case scope: PackageScope =>
         scope.succeed()
       case scope: TemplateScope =>
-        reporter.pos = scope.tree.point
         trySucceed(env, scope)
       case scope: SuperScope =>
         unreachable(scope)

--- a/rsc/src/main/scala/rsc/typecheck/Typechecker.scala
+++ b/rsc/src/main/scala/rsc/typecheck/Typechecker.scala
@@ -14,38 +14,30 @@ final class Typechecker private (
     reporter: Reporter,
     symtab: Symtab) {
   def apply(env: Env, tree: Typeable): Type = {
-    if (tree.pos != NoPosition) {
-      val oldPos = reporter.pos
-      reporter.pos = tree.point
-      val result = tree match {
-        case tree: Init => init(env, tree)
-        case tree: TermApply => termApply(env, tree)
-        case tree: TermApplyInfix => termApplyInfix(env, tree)
-        case tree: TermApplyPrefix => termApplyPrefix(env, tree)
-        case tree: TermApplyType => termApplyType(env, tree)
-        case tree: TermAssign => termAssign(env, tree)
-        case tree: TermBlock => termBlock(env, tree)
-        case tree: TermFunction => termFunction(env, tree)
-        case tree: TermId => termId(env, tree)
-        case tree: TermIf => termIf(env, tree)
-        case tree: TermLit => termLit(env, tree)
-        case tree: TermMatch => termMatch(env, tree)
-        case tree: TermNew => termNew(env, tree)
-        case tree: TermReturn => termReturn(env, tree)
-        case tree: TermSelect => termSelect(env, tree)
-        case tree: TermSuper => termSuper(env, tree)
-        case tree: TermThis => termThis(env, tree)
-        case tree: TermThrow => termThrow(env, tree)
-        case tree: TermWhile => termWhile(env, tree)
-        case tree: TptApply => tptApply(env, tree)
-        case tree: TptId => tptId(env, tree)
-        case tree: TptSelect => tptSelect(env, tree)
-        case _ => unreachable(tree)
-      }
-      reporter.pos = oldPos
-      result
-    } else {
-      unreachable(tree)
+    tree match {
+      case tree: Init => init(env, tree)
+      case tree: TermApply => termApply(env, tree)
+      case tree: TermApplyInfix => termApplyInfix(env, tree)
+      case tree: TermApplyPrefix => termApplyPrefix(env, tree)
+      case tree: TermApplyType => termApplyType(env, tree)
+      case tree: TermAssign => termAssign(env, tree)
+      case tree: TermBlock => termBlock(env, tree)
+      case tree: TermFunction => termFunction(env, tree)
+      case tree: TermId => termId(env, tree)
+      case tree: TermIf => termIf(env, tree)
+      case tree: TermLit => termLit(env, tree)
+      case tree: TermMatch => termMatch(env, tree)
+      case tree: TermNew => termNew(env, tree)
+      case tree: TermReturn => termReturn(env, tree)
+      case tree: TermSelect => termSelect(env, tree)
+      case tree: TermSuper => termSuper(env, tree)
+      case tree: TermThis => termThis(env, tree)
+      case tree: TermThrow => termThrow(env, tree)
+      case tree: TermWhile => termWhile(env, tree)
+      case tree: TptApply => tptApply(env, tree)
+      case tree: TptId => tptId(env, tree)
+      case tree: TptSelect => tptSelect(env, tree)
+      case _ => unreachable(tree)
     }
   }
 
@@ -233,7 +225,6 @@ final class Typechecker private (
       case caseDef @ Case(pat, cond, stats) =>
         val scope = FlatScope("case")
         def loop(pat: Pat): Unit = {
-          reporter.pos = pat.point
           pat match {
             case pat: PatAlternative =>
               pat.pats.foreach(loop)
@@ -269,7 +260,6 @@ final class Typechecker private (
           }
         }
         loop(pat)
-        reporter.pos = caseDef.point
         scope.succeed()
         val env1 = scope :: env
         cond.foreach(apply(env1, _))


### PR DESCRIPTION
Previously, we used to track the position of the currently processed node
to be able to correlate compiler crashes with precise positions.
Turns out that this significantly slows down the compiler.

Here are the results of running `bin/bench CI`:
```
   <tr>
     <td width="208px"><a href="../bench/rsc/jvm/src/main/scala/rsc/bench/RscNativeSchedule.scala">RscNativeSchedule</a></td>
-    <td width="208px">52.571 ms</td>
-    <td width="208px">38.234 ms</td>
+    <td width="208px">52.243 ms</td>
+    <td width="208px">38.617 ms</td>
   </tr>
   <tr>
     <td><a href="../bench/rsc/jvm/src/main/scala/rsc/bench/RscSchedule.scala">RscSchedule</a></td>
-    <td>339.965 ± 1.698 ms</td>
-    <td>10.619 ± 0.007 ms</td>
+    <td>336.474 ± 1.364 ms</td>
+    <td>10.596 ± 0.007 ms</td>
   </tr>
   <tr>
     <td><a href="../bench/scalac211/src/main/scala/rsc/bench/ScalacNamer211.scala">ScalacNamer211</a></td>
@@ -91,13 +91,13 @@ To reproduce, run `bin/bench` (this will take a while).
   </th>
   <tr>
     <td width="208px"><a href="../bench/rsc/jvm/src/main/scala/rsc/bench/RscNativeTypecheck.scala">RscNativeTypecheck</a></td>
-    <td width="208px">99.707 ms</td>
-    <td width="208px">71.346 ms</td>
+    <td width="208px">97.738 ms</td>
+    <td width="208px">70.501 ms</td>
   </tr>
   <tr>
     <td><a href="../bench/rsc/jvm/src/main/scala/rsc/bench/RscTypecheck.scala">RscTypecheck</a></td>
-    <td>460.705 ± 2.718 ms</td>
-    <td>32.498 ± 0.017 ms</td>
+    <td>446.065 ± 2.206 ms</td>
+    <td>26.824 ± 0.011 ms</td>
   </tr>
```