### PR TITLE
Change merge strategy to squash merge

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -83,10 +83,8 @@
     * If your work consists of multiple independent changes, you should split
     them into multiple commits - one commit per change, each accompanied by
     a detailed commit message as described above.
-    * If your work consists of multiple commits, each commit should be usable
-    in isolation - that is, each commit must build and pass all tests.
   * History
-    * Pull requests are merged using rebase merge, which means that pull request
+    * Pull requests are merged using squash merge, which means that pull request
     branches should always be rebased on top of master. Therefore, it's
     strongly recommended to not perform any merges on branches that you are
     planning to use for pull requests.


### PR DESCRIPTION
It is too costly to run tests and benchmarks on every commit
of every pull request, so we decided to switch from rebase merge
to squash merge.

I used to dislike squash merge, because I thought that it loses
historical information. However, I was incorrect. The commit produced
by squash merge has a link to the original pull request, so it should
be possible to do full-blown code archaeology if necessary.  