### PR TITLE
Simplify forSome statements into wildcard existentials (fix #471)

### DIFF
--- a/scalafix/input/src/main/scala/rsc/tests/BetterRscCompat.scala
+++ b/scalafix/input/src/main/scala/rsc/tests/BetterRscCompat.scala
@@ -283,4 +283,18 @@ object BetterRscCompat_Test {
 
     class H extends V
   }
+
+  object ExistentialTypes {
+    class Box[A]
+    class Box2[A, B]
+    trait T
+    class A extends T
+    class B extends T
+
+    val box = null.asInstanceOf[Box[_]]
+
+    val boxes1 = Seq(new Box[A], new Box[B])
+
+    val boxes2 = Seq(new Box2[A, B], new Box2[B, A])
+  }
 }

--- a/scalafix/output/src/main/scala/rsc/tests/BetterRscCompat.scala
+++ b/scalafix/output/src/main/scala/rsc/tests/BetterRscCompat.scala
@@ -283,4 +283,18 @@ object BetterRscCompat_Test {
 
     class H extends V
   }
+
+  object ExistentialTypes {
+    class Box[A]
+    class Box2[A, B]
+    trait T
+    class A extends T
+    class B extends T
+
+    val box: Box[_] = null.asInstanceOf[Box[_]]
+
+    val boxes1: Seq[Box[_]] = Seq(new Box[A], new Box[B])
+
+    val boxes2: Seq[Box2[_, _]] = Seq(new Box2[A, B], new Box2[B, A])
+  }
 }


### PR DESCRIPTION
Also fixes #353 

This will prevent unreadable existential types from being ascribed, as well as circumventing a bug where an existential type might be qualified: `Box[MyScope._1] forSome { type _1 ... }`. 